### PR TITLE
Turn off source maps in custom example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ browserify('entry.js')
     .plugin('common-shakeify')
     .plugin('browser-pack-flat/plugin')
     .bundle()
-    .pipe(require('minify-stream')())
+    .pipe(require('minify-stream')({ sourceMap: false }))
     .pipe(fs.createWriteStream('./output.js'))
 ```
 


### PR DESCRIPTION
I was doing some copy and paste evaluating and noticed my bundles were pretty big still. Then I had a peek inside and noticed source maps were still there.

For anyone unfamiliar with the various plugins, I thought a change like this would give them quick feedback on the savings they might expect (and it also highlights the option). Of course, the correct solution might be to extract it with exorcist but seeing as `debug` hasn't been turned on in the rest of the example, and there is a fair amount to understand already, maybe this is more straightforward.