### PR TITLE
deps: use @browserify/uglifyify

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var commonShake = require('common-shakeify')
 var unassertify = require('unassertify')
 var uglify = require('minify-stream')
 var envify = require('@browserify/envify/custom')
-var uglifyify = require('uglifyify')
+var uglifyify = require('@browserify/uglifyify')
 
 function makeUglifyOptions (debug) {
   var uglifyOpts = {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "common-shakeify": "^1.1.1",
     "minify-stream": "^2.0.1",
     "multisplice": "^1.0.0",
+    "terser": "3.16.1",
     "through2": "^4.0.2",
     "unassertify": "^2.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@browserify/envify": "^6.0.0",
+    "@browserify/uglifyify": "^6.0.0",
     "acorn-node": "^1.8.2",
     "browser-pack-flat": "^3.0.9",
     "bundle-collapser": "^1.3.0",
@@ -15,7 +16,6 @@
     "minify-stream": "^2.0.1",
     "multisplice": "^1.0.0",
     "through2": "^4.0.2",
-    "uglifyify": "^5.0.0",
     "unassertify": "^2.1.1"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -22,8 +22,8 @@ browserify -p tinyify app.js
 ## Included
 
  - [unassertify][] - Remove `assert()` calls
- - [envify][] - Replace environment variables—by default, replaces `NODE_ENV` with `"production"`
- - [uglifyify][] - Remove dead code from modules
+ - [@browserify/envify][] - Replace environment variables—by default, replaces `NODE_ENV` with `"production"`
+ - [@browserify/uglifyify][] - Remove dead code from modules
  - [common-shakeify][] - Remove unused exports from modules
  - [browser-pack-flat][] - Output a "flat" bundle, with all modules in a single scope
  - [bundle-collapser][] - When using the `--no-flat` option, bundle-collapser replaces file paths in `require()` calls with short module IDs
@@ -38,7 +38,7 @@ Options can be provided on the command line using subarg syntax, or in a separat
 
 ### `env: {}`
 
-Supply custom environment variables for [envify][].
+Supply custom environment variables for [@browserify/envify][].
 
 ```js
 b.plugin('tinyify', {
@@ -73,14 +73,14 @@ b.plugin('tinyify', { flat: false })
 If you need further customisation, I recommend installing the tools separately instead:
 
 ```bash
-npm install --save-dev unassertify @browserify/envify uglifyify common-shakeify browser-pack-flat uglify-js
+npm install --save-dev unassertify @browserify/envify @browserify/uglifyify common-shakeify browser-pack-flat terser
 browserify entry.js \
   -g unassertify \
   -g @browserify/envify \
-  -g uglifyify \
+  -g @browserify/uglifyify \
   -p common-shakeify \
   -p browser-pack-flat/plugin \
-| uglifyjs -cm \
+| terser -cm \
 > output.js
 ```
 
@@ -90,7 +90,7 @@ Or with the Node API:
 browserify('entry.js')
     .transform('unassertify', { global: true })
     .transform('@browserify/envify', { global: true })
-    .transform('uglifyify', { global: true })
+    .transform('@browserify/uglifyify', { global: true })
     .plugin('common-shakeify')
     .plugin('browser-pack-flat/plugin')
     .bundle()
@@ -105,8 +105,8 @@ Alternatively you can fork this repo and publish it on npm under a scope with yo
 [Apache-2.0](./LICENSE.md)
 
 [unassertify]: https://github.com/unassert-js/unassertify
-[envify]: https://github.com/browserify/envify
-[uglifyify]: https://github.com/hughsk/uglifyify
+[@browserify/envify]: https://github.com/browserify/envify
+[@browserify/uglifyify]: https://github.com/browserify/uglifyify
 [common-shakeify]: https://github.com/browserify/common-shakeify
 [browser-pack-flat]: https://github.com/goto-bus-stop/browser-pack-flat
 [bundle-collapser]: https://github.com/substack/bundle-collapser


### PR DESCRIPTION
This fork of uglifyify supports Terser's new async API as well as older sync APIs.

Fixes #32 as the new terser version supports `_` number separators.